### PR TITLE
[BE][Cron] Change to trigger keepAlive.js in GHA

### DIFF
--- a/.github/workflows/self-awakening.yaml
+++ b/.github/workflows/self-awakening.yaml
@@ -1,11 +1,8 @@
 name: self-awakening
 
 on:
-    # schedule:
-    #   - cron: '*/15 * * * *'
-    pull_request:
-        branches:
-            'main'
+    schedule:
+      - cron: '*/15 * * * *'
 
 jobs:
     Keep-Alive:

--- a/.github/workflows/self-awakening.yaml
+++ b/.github/workflows/self-awakening.yaml
@@ -1,0 +1,29 @@
+name: self-awakening
+
+on:
+    # schedule:
+    #   - cron: '*/15 * * * *'
+    pull_request:
+        branches:
+            'main'
+
+jobs:
+    Keep-Alive:
+        runs-on:
+            ubuntu-latest
+        
+        steps:
+            - name: checkout code
+              uses: actions/checkout@v4
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v3
+              with:
+                node-version: '18'
+        
+            - name: Install dependencies
+              run: npm install node-fetch
+            
+            - name: Cron job start
+              run: node ./tools/keepAlive.js
+

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "response_helper_service",
   "version": "1.0.0",
-  "description": "Server side of Response helper chrome extension.",
+  "description": "Server side of Response helper website and chrome extension.",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "concurrently \"node server.js\" \"node ./tools/keepAlive.js\""
   },
   "type": "module",
@@ -19,5 +19,12 @@
     "express": "^4.19.2",
     "node-fetch": "^3.3.2",
     "openai": "^4.52.7"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.25.2",
+    "@babel/preset-env": "^7.25.3",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0",
+    "jest-fetch-mock": "^3.0.3"
   }
 }

--- a/tools/keepAlive.js
+++ b/tools/keepAlive.js
@@ -1,8 +1,9 @@
 import fetch from "node-fetch";
+const apiDomain = 'https://response-helper-service.onrender.com'
 
 const keepAlive = async () => {
   try {
-    const response = await fetch('http://localhost:3000/api/wakeup');
+    const response = await fetch(`${apiDomain}/api/wakeup`);
     const data = await response.text();
     console.log('Pinged API successfully:', data);
   } catch (error) {
@@ -10,4 +11,4 @@ const keepAlive = async () => {
   }
 };
 
-setInterval(keepAlive, 60000);
+await keepAlive();


### PR DESCRIPTION
### Description
- Due to self-alive is not working in Render.com, need to trigger from outside of domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a scheduled GitHub Actions workflow to maintain application "keep-alive" functionality, running every 15 minutes.
  - Updated API endpoint in the keep-alive functionality to point to an external service.

- **Improvements**
  - Expanded project description in `package.json` to reflect broader service scope.
  - Modified test script in `package.json` to use Jest, enhancing testing practices.
  - Added new development dependencies to support modern JavaScript features and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->